### PR TITLE
feature(project): add postinstall npm script, which is npm run typings

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,11 @@
 
 # Quick start
 ```bash
-# install npm & typings dependencies
-npm install && npm run typings
+# install npm global dependencies as necessary
+npm install -g typescript typings
+
+# install npm local dependencies
+npm install
 
 # build and run the production server
 npm start

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "homepage": "http://www.angular2starterkit.com",
   "scripts": {
+    "postinstall": "npm run typings",
     "reinstall": "npm run clean:dist && rimraf node_modules && npm install",
     "clean": "rimraf dist logs",
     "clean:dist": "rimraf dist",


### PR DESCRIPTION
This tripped me up at first because I didn't read the README carefully. Now the install process is a little simpler. Updated README to reflect this.
